### PR TITLE
Removed unnecessary call to __getUrl

### DIFF
--- a/uploadcare/lib/5.3-5.4/Api.php
+++ b/uploadcare/lib/5.3-5.4/Api.php
@@ -183,8 +183,6 @@ class Api
    */
   public function __preparedRequest($type, $request_type = REQUEST_TYPE_GET, $params = array())
   {
-    $url = $this->__getUrl($type, $params);
-
     $ch = $this->__initRequest($type, $params);
     $this->__setRequestType($ch, $request_type);
     $this->__setHeaders($ch);


### PR DESCRIPTION
The url variable is not being used.
(The url is being calculated inside the __initRequest function.)

---

addresses #7
