### PR TITLE
Fix copyFile issue for custom storage

### DIFF
--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -164,7 +164,7 @@ class Api
   {
     $data = $this->__preparedRequest('file_copy', 'POST', array(), array('source' => $source, 'target' => $target));
     if (key_exists('result', (array)$data) == true) {
-      return new File((string)$data->result->uuid, $this);
+      return new File((string)$data->result, $this);
     } else {
       return (string)$data->detail;
     }


### PR DESCRIPTION
Kept getting "ErrorException: Trying to get property of non-object"

There is no `uuid` inside $data->result. $data->result is already a string.