### PR TITLE
Add support for full-featured cdn_host

### DIFF
--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -363,7 +363,8 @@ class Api
     
     $url = $url_parts['scheme'] . '://';
     
-    // there is basic HTTP auth
+    $basic_auth = '';
+    // check if there is a basic HTTP auth
     if (isset($url_parts['user'])) {
       $basic_auth = $url_parts['user'];
       
@@ -373,17 +374,19 @@ class Api
       }
       
       $basic_auth .= '@';
-    } else {
-      $basic_auth = '';
+    }
+    
+    $port = '';
+    if (isset($url_parts['port'])) {
+      $port = ':' . $url_parts['port']. 
     }
     
     $path = '';
-    
     if (isset($url_scheme['path'])) {
       $path = rtrim($url_scheme['path']);
     }
     
-    $this->cdn_host = $url_parts['scheme'] . '://' . $basic_auth . $url_parts['host'] . $path;
+    $this->cdn_host = $url_parts['scheme'] . '://' . $basic_auth . $url_parts['host'] . $port . $path;
   }
 
   /**

--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -383,7 +383,7 @@ class Api
     
     $path = '';
     if (isset($url_parts['path'])) {
-      $path = rtrim($url_parts['path']);
+      $path = rtrim($url_parts['path'], '/');
     }
     
     $this->cdn_host = $url_parts['scheme'] . '://' . $basic_auth . $url_parts['host'] . $port . $path;

--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -349,7 +349,7 @@ class Api
    */
   public function setCdnHost($cdn_host)
   {
-    $url_parts = parse_url($cdn_host) + ['scheme' => 'http'];
+    $url_parts = parse_url($cdn_host) + array('scheme' => 'http');
     
     // if no scheme was presented in $cdn_host
     if (!isset($url_parts['host'])) {

--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -382,8 +382,8 @@ class Api
     }
     
     $path = '';
-    if (isset($url_scheme['path'])) {
-      $path = rtrim($url_scheme['path']);
+    if (isset($url_parts['path'])) {
+      $path = rtrim($url_parts['path']);
     }
     
     $this->cdn_host = $url_parts['scheme'] . '://' . $basic_auth . $url_parts['host'] . $port . $path;

--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -378,7 +378,7 @@ class Api
     
     $port = '';
     if (isset($url_parts['port'])) {
-      $port = ':' . $url_parts['port']. 
+      $port = ':' . $url_parts['port'];
     }
     
     $path = '';

--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -153,7 +153,7 @@ class File
    */
   public function getUrl($postfix = null)
   {
-    $url = sprintf('http://%s/%s/', $this->api->cdn_host, $this->uuid);
+    $url = sprintf('%s/%s/', $this->api->cdn_host, $this->uuid);
     if($this->default_effects) {
       $url = sprintf('%s-/%s', $url, $this->default_effects);
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -276,6 +276,10 @@ class ApiTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($file->resize(400, 400)->getUrl(), 'http://example.com/3c99da1d-ef05-4d79-81d8-d4f208d98beb/-/resize/400x400/');
     $this->assertEquals($file->resize(400, false)->getUrl(), 'http://example.com/3c99da1d-ef05-4d79-81d8-d4f208d98beb/-/resize/400x/');
     $this->assertEquals($file->resize(false, 400)->getUrl(), 'http://example.com/3c99da1d-ef05-4d79-81d8-d4f208d98beb/-/resize/x400/');
+    
+    // Check user can use full-featured CDN host
+    $api->setCdnHost('https://user:pass@example.com:4433/path/');
+    $this->assertEquals($file->getUrl(), 'https://user:pass@example.com:4433/path/3c99da1d-ef05-4d79-81d8-d4f208d98beb/');
   }
 
   /**


### PR DESCRIPTION
Now it is possible to pass as `cdn_host` full-featured urls like this: `https://user:pass@example.com:4433/path/`