### PR TITLE
Don't throw warning for demo API keys with phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
          stopOnFailure="false"
          syntaxCheck="false"
 >
+    <php>
+        <const name="PHPUNIT_UPLOADCARE_TESTSUITE" value="true"/>
+    </php>
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -200,7 +200,7 @@ class Api
       }
     }
     curl_close($ch);
-    if ($this->public_key == 'demopublickey' || $this->secret_key == 'demoprivatekey') {
+    if (!defined('PHPUNIT_UPLOADCARE_TESTSUITE') && ($this->public_key == 'demopublickey' || $this->secret_key == 'demoprivatekey')) {
       trigger_error('You are using the demo account. Please get an Uploadcare account at https://uploadcare.com/accounts/create/', E_USER_WARNING);
     }
     return json_decode($data);


### PR DESCRIPTION
When running `phpunit`, there were multiple warnings about using the demo account: "Warning: You are using the demo account. Please get an Uploadcare account at ..."
