### PR TITLE
copyFile return based on type

### DIFF
--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -164,7 +164,11 @@ class Api
   {
     $data = $this->__preparedRequest('file_copy', 'POST', array(), array('source' => $source, 'target' => $target));
     if (key_exists('result', (array)$data) == true) {
-      return new File((string)$data->result->uuid, $this);
+      if ($data->type == 'file') {
+        return new File((string)$data->result->uuid, $this);
+      } else {
+        return (string)$data->result;
+      }
     } else {
       return (string)$data->detail;
     }

--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -129,10 +129,22 @@ class File
    * Copy the file.
    *
    * @param string $target Name of custom storage.
+   * @return File|string
    */
   public function copy($target = null)
   {
     return $this->api->copyFile($this->getUrl(), $target);
+  }
+
+  /**
+   * Copy the file to custom storage.
+   *
+   * @param string $target Name of custom storage.
+   * @return string
+   */
+  public function copyTo($target)
+  {
+    return (string)$this->copy($target);
   }
 
   /**


### PR DESCRIPTION
Per the discussion in PR #31 this change does two things:
- Fixes the `Api::copyFile` method to only return a `File` instance if the API response type is `file` otherwise it returns a string.
- Adds a convience method to the File class `copyTo` that expects a `$target` but otherwise works exactly like `copy`
