### PR TITLE
Rest api v0.5 store file name from url

### DIFF
--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -51,12 +51,12 @@ class Uploader
    * @param boolean $check_status Wait till upload is complete
    * @param int $timeout Wait $timeout seconds between status checks
    * @param int $max_attempts Check status no more than $max_attempts times
-   * @param array $uploadParams Optioanal dictionary with additional params. Available keys are follwing:
+   * @param array $upload_params Optioanal dictionary with additional params. Available keys are follwing:
    * 'store' - can be true, false or 'auto'. This flag indicates should file be stored automatically after upload.
    * 'filename' - should be a string, Sets explicitly file name of uploaded file.
    * 'check_status' - Wait till upload is complete
    * 'timeout' - Wait number of seconds between status checks
-   * 'max_attempts' - Check status no more than $max_attempts times
+   * 'max_attempts' - Check status no more than passed number of times
    * @return File|string
    * @throws \Exception
    */

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -54,7 +54,7 @@ class Uploader
    * @return File|string
    * @throws \Exception
    */
-  public function fromUrl($url, $fileName = null, $store = true, $check_status = true, $timeout = 1, $max_attempts = 5)
+  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $fileName = null, $store = 'auto')
   {
     $requestData = array(
         '_' => time(),

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -65,16 +65,11 @@ class Uploader
   /**
    * Upload file from url and get File instance
    *
+   * @deprecated 2.0.0 please use fromUrlNewfromUrlNew($url, $options) instead
    * @param string $url An url of file to be uploaded.
-   * @deprecated 2.0.0 boolean $check_status Wait till upload is complete, pass this parameter in the $options array
-   * @deprecated 2.0.0 int $timeout Wait $timeout seconds between status checks, pass this parameter in the $options array
-   * @deprecated 2.0.0 int $max_attempts Check status no more than $max_attempts times, pass this parameter in the $options array
-   * @param array $options Optioanal dictionary with additional params. Available keys are following:
-   * 'store' - can be true, false or 'auto'. This flag indicates should file be stored automatically after upload.
-   * 'filename' - should be a string, Sets explicitly file name of uploaded file.
-   * 'check_status' - Wait till upload is complete
-   * 'timeout' - Wait number of seconds between status checks
-   * 'max_attempts' - Check status no more than passed number of times
+   * @param boolean $check_status Wait till upload is complete
+   * @param int $timeout Wait $timeout seconds between status checks
+   * @param int $max_attempts Check status no more than $max_attempts times
    * @return File|string
    * @throws \Exception
    */
@@ -88,6 +83,19 @@ class Uploader
     ));
   }
 
+  /**
+   * Upload file from url and get File instance
+   *
+   * @param string $url An url of file to be uploaded.
+   * @param array $options Optioanal dictionary with additional params. Available keys are following:
+   * 'store' - can be true, false or 'auto'. This flag indicates should file be stored automatically after upload.
+   * 'filename' - should be a string, Sets explicitly file name of uploaded file.
+   * 'check_status' - Wait till upload is complete
+   * 'timeout' - Wait number of seconds between status checks
+   * 'max_attempts' - Check status no more than passed number of times
+   * @return File|string
+   * @throws \Exception
+   */
   private function fromUrlNew($url, $options = array())
   {
     $default_options = array(

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -54,13 +54,18 @@ class Uploader
    * @return File|string
    * @throws \Exception
    */
-  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5)
+  public function fromUrl($url, $fileName = null, $store = true, $check_status = true, $timeout = 1, $max_attempts = 5)
   {
     $requestData = array(
         '_' => time(),
         'source_url' => $url,
         'pub_key' => $this->api->getPublicKey(),
+        'store' => $store,
     );
+    if(!!$fileName) {
+      $requestData['filename'] = $fileName;
+    }
+
     $ch = $this->__initRequest('from_url', $requestData);
     $this->__setHeaders($ch);
 

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -51,19 +51,28 @@ class Uploader
    * @param boolean $check_status Wait till upload is complete
    * @param int $timeout Wait $timeout seconds between status checks
    * @param int $max_attempts Check status no more than $max_attempts times
+   * @param array $uploadParams Optioanal dictionary with additional params. Available keys are follwing:
+   * 'store' - can be true, false or 'auto'. This flag indicates should file be stored automatically after upload.
+   * 'filename' - should be a string, Sets explicitly file name of uploaded file.
    * @return File|string
    * @throws \Exception
    */
-  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $fileName = null, $store = 'auto')
+  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $uploadParams = array())
   {
+    $defParams = array(
+      'store' => 'auto',
+      'filename' => null,
+    );
+    $params = array_merge($defParams, $uploadParams);
+    
     $requestData = array(
         '_' => time(),
         'source_url' => $url,
         'pub_key' => $this->api->getPublicKey(),
-        'store' => $store,
+        'store' => $params['store'],
     );
-    if(!!$fileName) {
-      $requestData['filename'] = $fileName;
+    if($params['filename']) {
+      $requestData['filename'] = $params['filename'];
     }
 
     $ch = $this->__initRequest('from_url', $requestData);

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -48,10 +48,10 @@ class Uploader
    * Upload file from url and get File instance
    *
    * @param string $url An url of file to be uploaded.
-   * @param boolean $check_status Wait till upload is complete
-   * @param int $timeout Wait $timeout seconds between status checks
-   * @param int $max_attempts Check status no more than $max_attempts times
-   * @param array $upload_params Optioanal dictionary with additional params. Available keys are follwing:
+   * @deprecated 2.0.0 boolean $check_status Wait till upload is complete, pass this parameter in the $options array
+   * @deprecated 2.0.0 int $timeout Wait $timeout seconds between status checks, pass this parameter in the $options array
+   * @deprecated 2.0.0 int $max_attempts Check status no more than $max_attempts times, pass this parameter in the $options array
+   * @param array $options Optioanal dictionary with additional params. Available keys are following:
    * 'store' - can be true, false or 'auto'. This flag indicates should file be stored automatically after upload.
    * 'filename' - should be a string, Sets explicitly file name of uploaded file.
    * 'check_status' - Wait till upload is complete
@@ -60,34 +60,34 @@ class Uploader
    * @return File|string
    * @throws \Exception
    */
-  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $upload_params = array())
+  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $options = array())
   {
-    $defParams = array(
+    $default_options = array(
       'store' => 'auto',
       'filename' => null,
       'check_status' => true,
       'timeout' => 1,
       'max_attempts' => 5
     );
-    $params = array_merge($defParams, $upload_params);
+    $params = array_merge($default_options, $options);
     
     if(!$check_status) {
-      Helper::deprecate('2.0.0', '3.0.0', '$check_status input variable is deprecated, now it`s moved to the $upload_params with key `check_status`');
+      Helper::deprecate('2.0.0', '3.0.0', '$check_status input variable is deprecated, now it`s moved to the $options with key `check_status`');
     }
     if($timeout != 1) {
-      Helper::deprecate('2.0.0', '3.0.0', '$timeout input variable is deprecated, it`s moved to the $upload_params with key `timeout`');
+      Helper::deprecate('2.0.0', '3.0.0', '$timeout input variable is deprecated, it`s moved to the $options with key `timeout`');
     }
     if($max_attempts != 5) {
-      Helper::deprecate('2.0.0', '3.0.0', '$timeout input variable is deprecated, it`s moved to the $upload_params with key `max_attempts`');
+      Helper::deprecate('2.0.0', '3.0.0', '$timeout input variable is deprecated, it`s moved to the $options with key `max_attempts`');
     }
     if(!$check_status && !$$params['check_status']) {
-      trigger_error('input parameter `check_status` declared multiple times, as input variable and in the `$upload_params` array', E_USER_ERROR);
+      trigger_error('input parameter `check_status` declared multiple times, as input variable and in the `$options` array', E_USER_ERROR);
     }
     if($timeout != 1 && $params['timeout'] != 1) {
-      trigger_error('input parameter `timeout` declared multiple times, as input variable and in the `$upload_params` array', E_USER_ERROR);
+      trigger_error('input parameter `timeout` declared multiple times, as input variable and in the `$options` array', E_USER_ERROR);
     }
     if($max_attempts != 5 && $params['max_attempts'] != 5) {
-      trigger_error('input parameter `max_attempts` declared multiple times, as input variable and in the `$upload_params` array', E_USER_ERROR);
+      trigger_error('input parameter `max_attempts` declared multiple times, as input variable and in the `$options` array', E_USER_ERROR);
     }
     if($check_status && !$params['check_status']) {
       $check_status = $params['check_status'];

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -54,17 +54,51 @@ class Uploader
    * @param array $uploadParams Optioanal dictionary with additional params. Available keys are follwing:
    * 'store' - can be true, false or 'auto'. This flag indicates should file be stored automatically after upload.
    * 'filename' - should be a string, Sets explicitly file name of uploaded file.
+   * 'check_status' - Wait till upload is complete
+   * 'timeout' - Wait number of seconds between status checks
+   * 'max_attempts' - Check status no more than $max_attempts times
    * @return File|string
    * @throws \Exception
    */
-  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $uploadParams = array())
+  public function fromUrl($url, $check_status = true, $timeout = 1, $max_attempts = 5, $upload_params = array())
   {
     $defParams = array(
       'store' => 'auto',
       'filename' => null,
+      'check_status' => true,
+      'timeout' => 1,
+      'max_attempts' => 5
     );
-    $params = array_merge($defParams, $uploadParams);
+    $params = array_merge($defParams, $upload_params);
     
+    if(!$check_status) {
+      Helper::deprecate('2.0.0', '3.0.0', '$check_status input variable is deprecated, now it`s moved to the $upload_params with key `check_status`');
+    }
+    if($timeout != 1) {
+      Helper::deprecate('2.0.0', '3.0.0', '$timeout input variable is deprecated, it`s moved to the $upload_params with key `timeout`');
+    }
+    if($max_attempts != 5) {
+      Helper::deprecate('2.0.0', '3.0.0', '$timeout input variable is deprecated, it`s moved to the $upload_params with key `max_attempts`');
+    }
+    if(!$check_status && !$$params['check_status']) {
+      trigger_error('input parameter `check_status` declared multiple times, as input variable and in the `$upload_params` array', E_USER_ERROR);
+    }
+    if($timeout != 1 && $params['timeout'] != 1) {
+      trigger_error('input parameter `timeout` declared multiple times, as input variable and in the `$upload_params` array', E_USER_ERROR);
+    }
+    if($max_attempts != 5 && $params['max_attempts'] != 5) {
+      trigger_error('input parameter `max_attempts` declared multiple times, as input variable and in the `$upload_params` array', E_USER_ERROR);
+    }
+    if($check_status && !$params['check_status']) {
+      $check_status = $params['check_status'];
+    }
+    if($timeout == 1 && $params['timeout'] != 1) {
+      $timeout = $params['timeout'];
+    }
+    if($max_attempts == 5 && $params['max_attempts'] != 5) {
+      $max_attempts = $params['max_attempts'];
+    }
+
     $requestData = array(
         '_' => time(),
         'source_url' => $url,

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -287,7 +287,7 @@ class ApiTest extends TestCase
       'max_attempts' => 6,
     );
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $options);
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $options);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }
@@ -300,7 +300,7 @@ class ApiTest extends TestCase
 
     try {
       $options['store'] = false;
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $options);
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $options);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -279,12 +279,26 @@ class ApiTest extends TestCase
    */
   public function testUploadFromURL()
   {
+    $destFileName = 'IMG_1.jpg';
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg');
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $destFileName);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }
+    $data = $file->__get('data');
+    $fileName = $data["original_filename"];
     $this->assertEquals(get_class($file), 'Uploadcare\File');
+    $this->assertEquals($fileName, $destFileName);
+    $this->assertTrue(!!$data["datetime_stored"]);
+    $file->delete();
+
+    try {
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $destFileName, false);
+    } catch (Exception $e) {
+      $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
+    }
+    $data = $file->__get('data');
+    $this->assertTrue(!$data["datetime_stored"]);
     try {
       $file->store();
     } catch (Exception $e) {

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -279,25 +279,25 @@ class ApiTest extends TestCase
    */
   public function testUploadFromURL()
   {
-    $params = array(
+    $options = array(
       'filename' => 'IMG_1.jpg',
       'store' => true,
     );
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $params);
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $options);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }
     $data = $file->__get('data');
     $fileName = $data["original_filename"];
     $this->assertEquals(get_class($file), 'Uploadcare\File');
-    $this->assertEquals($fileName, $params['filename']);
+    $this->assertEquals($fileName, $options['filename']);
     $this->assertTrue(!!$data["datetime_stored"]);
     $file->delete();
 
     try {
-      $params['store'] = false;
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $params);
+      $options['store'] = false;
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $options);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -281,7 +281,7 @@ class ApiTest extends TestCase
   {
     $destFileName = 'IMG_1.jpg';
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $destFileName);
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5,$destFileName);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }
@@ -293,7 +293,7 @@ class ApiTest extends TestCase
     $file->delete();
 
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $destFileName, false);
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5,$destFileName, false);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -279,21 +279,25 @@ class ApiTest extends TestCase
    */
   public function testUploadFromURL()
   {
-    $destFileName = 'IMG_1.jpg';
+    $params = array(
+      'filename' => 'IMG_1.jpg',
+      'store' => true,
+    );
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5,$destFileName);
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $params);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }
     $data = $file->__get('data');
     $fileName = $data["original_filename"];
     $this->assertEquals(get_class($file), 'Uploadcare\File');
-    $this->assertEquals($fileName, $destFileName);
+    $this->assertEquals($fileName, $params['filename']);
     $this->assertTrue(!!$data["datetime_stored"]);
     $file->delete();
 
     try {
-      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5,$destFileName, false);
+      $params['store'] = false;
+      $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $params);
     } catch (Exception $e) {
       $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -365,7 +365,7 @@ class ApiTest extends TestCase
       $this->fail('We get an unexpected exception trying to store uploaded file from contents: '.$e->getMessage());
     }
 
-    usleep(500000);
+    usleep(2000000); // wait 2 sec to give a time to prepare file and avoid 404 error.
     $text = file_get_contents($file->getUrl());
     $this->assertEquals($text, "This is some text I want to upload");
   }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -282,6 +282,9 @@ class ApiTest extends TestCase
     $options = array(
       'filename' => 'IMG_1.jpg',
       'store' => true,
+      'check_status' => true,
+      'timeout' => 3,
+      'max_attempts' => 6,
     );
     try {
       $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', true, 1, 5, $options);


### PR DESCRIPTION
This pr resolves issue #79 

Changes contains:
- Added new input variable `$upload_params` with dictionary of method parameters.
- Moved dedicated parameters to $upload_params dictionary + added deprecated messages if use it.
- Fixed float CI error with 404 after upload text file.