### PR TITLE
Add more context to the UUID not found exception

### DIFF
--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -55,7 +55,7 @@ class File
   {
     $matches = array();
     if(!preg_match($this->re_uuid_with_effects, $uuid_or_url, $matches)) {
-      throw new \Exception('UUID not found');
+      throw new \Exception(sprintf('UUID "%s" not found', $uuid_or_url));
     }
 
     $this->uuid = $matches['uuid'];

--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -55,7 +55,7 @@ class File
   {
     $matches = array();
     if(!preg_match($this->re_uuid_with_effects, $uuid_or_url, $matches)) {
-      throw new \Exception(sprintf('UUID "%s" not found', $uuid_or_url));
+      throw new \Exception(sprintf('UUID or CDN URL cannot be found in "%s"', $uuid_or_url));
     }
 
     $this->uuid = $matches['uuid'];


### PR DESCRIPTION
We are getting the "UUID not found" exception regularly, but no context is given, so have have to add this on the client's side...