### PR TITLE
Fix of usage ?? with File->data and Group->data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.1.2
-- fix with usage `??` for `File->data` and `Group->data` for php 7.x see [error description](https://bugs.php.net/bug.php?id=71359)
+- fix of usage `??` with `File->data` and `Group->data` see [error description](https://bugs.php.net/bug.php?id=71359) Now its safe to use `$data = File->data ?? $defaultData;` or `$data = Group->data ?? $defaultData;`
 
 ## 2.1.1
 - fix `File->op()`

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.2
+- fix with usage `??` for `File->data` and `Group->data` for php 7.x see [error description](https://bugs.php.net/bug.php?id=71359)
+
 ## 2.1.1
 - fix `File->op()`
 

--- a/sample-project/editFile.php
+++ b/sample-project/editFile.php
@@ -52,7 +52,7 @@
       $file = $api->getFile($fileId);
       $imgUrl = $file->preview(400, 400)->getUrl();
       $uuid = $file->getUuid();
-      $data = $file->__get('data');
+      $data = $file->data;
       $fileName = $data["original_filename"];
       $imgInfo = $data["image_info"];
       $height = $imgInfo->height;

--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -4,7 +4,7 @@ namespace Uploadcare;
 
 use Uploadcare\Exceptions\ThrottledRequestException;
 
-$uploadcare_version = '2.1.1';
+$uploadcare_version = '2.1.2';
 define('UPLOADCARE_LIB_VERSION', sprintf('%s/%s.%s', $uploadcare_version, PHP_MAJOR_VERSION, PHP_MINOR_VERSION));
 
 class Api

--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -83,12 +83,24 @@ class File
     public function __get($name)
     {
         if ($name == 'data') {
-            if (!$this->cached_data) {
-                $this->updateInfo();
-            }
             return $this->cached_data;
         }
         return null;
+    }
+
+    public function __isSet($name)
+    {
+        if ($name == 'data') {
+            if (!$this->cached_data) {
+                try {
+                    $this->updateInfo();
+                } catch (\Exception $ex) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -83,6 +83,13 @@ class File
     public function __get($name)
     {
         if ($name == 'data') {
+            if (!$this->cached_data) {
+                try {
+                    $this->updateInfo();
+                } catch (\Exception $ex) {
+                    return null;
+                }
+            }
             return $this->cached_data;
         }
         return null;

--- a/src/Uploadcare/Group.php
+++ b/src/Uploadcare/Group.php
@@ -64,13 +64,24 @@ class Group
     public function __get($name)
     {
         if ($name == 'data') {
-            if (!$this->cached_data) {
-                $this->updateInfo();
-            }
             return $this->cached_data;
         }
-
         return null;
+    }
+
+    public function __isSet($name)
+    {
+        if ($name == 'data') {
+            if (!$this->cached_data) {
+                try {
+                    $this->updateInfo();
+                } catch (\Exception $ex) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/Uploadcare/Group.php
+++ b/src/Uploadcare/Group.php
@@ -64,6 +64,13 @@ class Group
     public function __get($name)
     {
         if ($name == 'data') {
+            if (!$this->cached_data) {
+                try {
+                    $this->updateInfo();
+                } catch (\Exception $ex) {
+                    return null;
+                }
+            }
             return $this->cached_data;
         }
         return null;


### PR DESCRIPTION
fix of usage `??` with `File->data` and `Group->data` see [error description](https://bugs.php.net/bug.php?id=71359) 
Now its safe to use `$data = File->data ?? $defaultData;` or `$data = Group->data ?? $defaultData;`