### PR TITLE
Improve IDE support on a virtual property

### DIFF
--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -2,6 +2,9 @@
 
 namespace Uploadcare;
 
+/**
+ * @property array $data File info
+ */
 class File
 {
     /**


### PR DESCRIPTION
This fixes IDE static analysis warning on a missing property being accessed.

```php
$data = $uploadcare->getFile($uuid)->data; // data is a virtual property
```