### PR TITLE
Wrong return type for createRemoteCopy

### DIFF
--- a/src/Uploadcare/Api.php
+++ b/src/Uploadcare/Api.php
@@ -522,7 +522,7 @@ class Api
      * ${uuid} = file UUID
      * ${ext} = file extension, leading dot, e.g. .jpg
      *
-     * @return File|string
+     * @return string
      * @throws \Exception
      */
     public function createRemoteCopy($source, $target, $make_public = true, $pattern = null)


### PR DESCRIPTION
As result is always casted to string, the return type should be `string`