### PR TITLE
Wrong return type for createRemoteCopy #2

### DIFF
--- a/src/Uploadcare/File.php
+++ b/src/Uploadcare/File.php
@@ -208,7 +208,7 @@ class File
      * ${uuid} = file UUID
      * ${ext} = file extension, leading dot, e.g. .jpg
      *
-     * @return File|string
+     * @return string
      * @throws \Exception
      */
     public function createRemoteCopy($target, $make_public = true, $pattern = '${default}')


### PR DESCRIPTION
This is follow up of #112, I missed this method signature which should also be updated.