### PR TITLE
Extract request parameters from options.

### DIFF
--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -163,9 +163,9 @@ class Uploader
         $this->__setHeaders($ch);
 
         $data = $this->__runRequest($ch);
-        $token = $data->token;
+        $token = isset($data->token) ? $data->token : null;
 
-        if ($check_status) {
+        if ($check_status && $token) {
             $success = false;
             $attempts = 0;
             while (!$success) {
@@ -182,7 +182,7 @@ class Uploader
                 sleep($timeout);
                 $attempts++;
             }
-        } else {
+        } elseif ($token) {
             return $token;
         }
         $uuid = $data->uuid;

--- a/src/Uploadcare/Uploader.php
+++ b/src/Uploadcare/Uploader.php
@@ -147,10 +147,13 @@ class Uploader
             '_' => time(),
             'source_url' => $url,
             'pub_key' => $this->api->getPublicKey(),
-            'store' => $params['store'],
         );
-        if ($params['filename']) {
-            $requestData['filename'] = $params['filename'];
+
+        $requestParameters = array('filename', 'store', 'save_URL_duplicates', 'check_URL_duplicates');
+        foreach ($requestParameters as $requestParameter) {
+            if (isset($params[$requestParameter]) && !is_null($requestParameter)) {
+                $requestData[$requestParameter] = $params[$requestParameter];
+            }
         }
 
         $requestData = $this->getSignedUploadsData($requestData);

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -371,6 +371,52 @@ class ApiTest extends TestCase
     }
 
     /**
+     * Test upload from URL
+     */
+    public function testUploadFromURLWithOptions()
+    {
+        $options = array(
+            'filename' => 'IMG_1.jpg',
+            'store' => true,
+            'check_status' => false,
+            'timeout' => 3,
+            'max_attempts' => 6,
+            'save_URL_duplicates' => true,
+            'check_URL_duplicates' => true,
+        );
+        try {
+            // We have to pre-upload in case file gets deleted from demo account
+            $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $options);
+        } catch (Exception $e) {
+            $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
+        }
+        try {
+            $file = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $options);
+        } catch (Exception $e) {
+            $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
+        }
+        $data = $file->__get('data');
+
+        $this->assertArrayHasKey('url', $data);
+        $this->assertArrayHasKey('uuid', $data);
+
+        $failOptions = array(
+            'filename' => 'IMG_1.jpg',
+            'store' => true,
+            'check_status' => false,
+            'timeout' => 3,
+            'max_attempts' => 6,
+        );
+
+        try {
+            $string = $this->api->uploader->fromUrl('https://www.baysflowers.co.nz/wp-content/uploads/2015/06/IMG_9886_2.jpg', $failOptions);
+        } catch (Exception $e) {
+            $this->fail('We get an unexpected exception trying to upload from url: '.$e->getMessage());
+        }
+        $this->assertInternalType('string', $string);
+    }
+
+    /**
      * Test uploading from path
      */
     public function testUploadFromPath()


### PR DESCRIPTION
Include options ('filename', 'store', 'save_URL_duplicates', 'check_URL_duplicates') in cURL request to [from_url](https://uploadcare.com/docs/api_reference/upload/from_url/). 

Options are added to request data only if they exist and are not null.

## Description
https://github.com/uploadcare/uploadcare-php/issues/127


