### PR TITLE
Allow to use guzzlehttp/guzzle:^7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": ">=5.6",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.5",
+    "guzzlehttp/guzzle": "^6.5||^7",
     "guzzlehttp/psr7": "^1.6",
     "symfony/polyfill-uuid": "^1.17"
   },

--- a/tests/Api/MultipartUploadTest.php
+++ b/tests/Api/MultipartUploadTest.php
@@ -52,7 +52,12 @@ class MultipartUploadTest extends TestCase
 
     public function testResponseExceptionInStartUpload()
     {
-        $exception = new ClientException('Wrong request', new Request('POST', 'uri'));
+        if (PHP_MAJOR_VERSION >= 7) {
+            $exception = new ClientException('Wrong request', new Request('POST', 'uri'), new Response(400));
+        } else {
+            $exception = new ClientException('Wrong request', new Request('POST', 'uri'));
+        }
+
         $uploader = $this->getMockUploader(['sendRequest']);
         $uploader
             ->expects(self::once())
@@ -69,7 +74,12 @@ class MultipartUploadTest extends TestCase
 
     public function testExceptionInUploadPartsMethod()
     {
-        $exception = new ClientException('Wrong request', new Request('POST', 'https://some-middleware-endpoint'));
+        if (PHP_MAJOR_VERSION >= 7) {
+            $exception = new ClientException('Wrong request', new Request('POST', 'https://some-middleware-endpoint'), new Response(400));
+        } else {
+            $exception = new ClientException('Wrong request', new Request('POST', 'https://some-middleware-endpoint'));
+        }
+
         $uploader = $this->getMockUploader(['sendRequest']);
         $uploader
             ->expects(self::once())
@@ -89,7 +99,12 @@ class MultipartUploadTest extends TestCase
 
     public function testExceptionInFinishUpload()
     {
-        $exception = new TooManyRedirectsException('Too many redirects', new Request('POST', 'https://final-endpoint'));
+        if (PHP_MAJOR_VERSION >= 7) {
+            $exception = new TooManyRedirectsException('Too many redirects', new Request('POST', 'https://final-endpoint'), new Response(400));
+        } else {
+            $exception = new TooManyRedirectsException('Too many redirects', new Request('POST', 'https://final-endpoint'));
+        }
+
         $uploader = $this->getMockUploader(['sendRequest']);
         $uploader
             ->expects(self::once())

--- a/tests/HttpExceptionTest.php
+++ b/tests/HttpExceptionTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Uploadcare\Exception\HttpException;
 
@@ -16,11 +17,21 @@ class HttpExceptionTest extends TestCase
     {
         $request = new Request('GET', 'https://localhost');
 
+        if (PHP_MAJOR_VERSION < 7) {
+            return [
+                [new RequestException('Wrong Request', $request)],
+                [new TooManyRedirectsException('Too many redirects', $request)],
+                [new ConnectException('Cant connect', $request)],
+                [new ServerException('Server made a boo-boo', $request)],
+                [new \RuntimeException('Some fail', 400)],
+            ];
+        }
+
         return [
-            [new RequestException('Wrong Request', $request)],
-            [new TooManyRedirectsException('Too many redirects', $request)],
+            [new RequestException('Wrong Request', $request, new Response(400))],
+            [new TooManyRedirectsException('Too many redirects', $request, new Response(400))],
             [new ConnectException('Cant connect', $request)],
-            [new ServerException('Server made a boo-boo', $request)],
+            [new ServerException('Server made a boo-boo', $request, new Response(400))],
             [new \RuntimeException('Some fail', 400)],
         ];
     }
@@ -38,7 +49,11 @@ class HttpExceptionTest extends TestCase
 
     public function testEmptyMessageInException()
     {
-        $ex = new ServerException('', new Request('GET', 'https://localhost'));
+        if (PHP_MAJOR_VERSION < 7) {
+            $ex = new ServerException('', new Request('GET', 'https://localhost'));
+        } else {
+            $ex = new ServerException('', new Request('GET', 'https://localhost'), new Response(400));
+        }
         $httpException = new HttpException('', 503, $ex);
         self::assertContains('Fail', $httpException->getMessage());
         self::assertEquals(503, $httpException->getCode());

--- a/tests/Uploader/UploaderServiceTest.php
+++ b/tests/Uploader/UploaderServiceTest.php
@@ -213,6 +213,9 @@ class UploaderServiceTest extends TestCase
         return $this->getMockUploader($conf);
     }
 
+    /**
+     * @requires PHP <= 5
+     */
     public function testSendRequestMethodHeaders()
     {
         $uploader = $this->checkClientRequestArgument(2);
@@ -226,6 +229,9 @@ class UploaderServiceTest extends TestCase
         self::assertArrayHasKey('headers', $result);
     }
 
+    /**
+     * @requires PHP <= 5
+     */
     public function testSendRequestMethodUri()
     {
         $uploader = $this->checkClientRequestArgument(1);


### PR DESCRIPTION
## Description

Allow to use guzzlehttp/guzzle:^7

## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
