### PR TITLE
Allow to set framework / CMS version to library user-agent header

### DIFF
--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -77,4 +77,13 @@ class ConfigurationTest extends TestCase
         self::assertArrayHasKey('User-Agent', $result);
         self::assertSame($this->header, $result['User-Agent']);
     }
+
+    public function testHeaderWithFramework()
+    {
+        $conf = Configuration::create($this->publicKey, $this->privateKey, ['framework' => ['Symfony', '5.1']]);
+        $result = $conf->getHeaders();
+        self::assertArrayHasKey('User-Agent', $result);
+        self::assertContains('Symfony', $result['User-Agent']);
+        self::assertContains('5.1', $result['User-Agent']);
+    }
 }

--- a/tests/Uploader/UploaderServiceTest.php
+++ b/tests/Uploader/UploaderServiceTest.php
@@ -214,7 +214,7 @@ class UploaderServiceTest extends TestCase
     }
 
     /**
-     * @requires PHP <= 5
+     * @requires PHP <= 7
      */
     public function testSendRequestMethodHeaders()
     {
@@ -230,7 +230,7 @@ class UploaderServiceTest extends TestCase
     }
 
     /**
-     * @requires PHP <= 5
+     * @requires PHP <= 7
      */
     public function testSendRequestMethodUri()
     {


### PR DESCRIPTION
## Description

Allow to set framework / CMS version to library user-agent header

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
