### PR TITLE
Fix: copy file between storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based now on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.3]
+### Fix
+- Copy file from local (uploadcare) to remote (s3) storage and vise versa.
+
 ## [3.0.2]
 ### Fix
 - Serialization for `originalFileUrl`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 
 ## [3.0.3]
 ### Fix
-- Copy file from local (uploadcare) to remote (s3) storage and vise versa.
+- Fixed file copy methods between default Uploadcare storage and remote storage (Amazon s3)
 
 ## [3.0.2]
 ### Fix

--- a/src/Apis/AbstractApi.php
+++ b/src/Apis/AbstractApi.php
@@ -89,7 +89,7 @@ abstract class AbstractApi
         $headers['Accept'] = \sprintf('application/vnd.uploadcare-v%s+json', Configuration::API_VERSION);
         $headers = \array_merge($this->configuration->getHeaders(), $headers);
         if (\strpos($uri, 'http') !== 0) {
-            $uri = \sprintf('https://%s/%s', Configuration::API_BASE_URL, $uri);
+            $uri = \sprintf('https://%s/%s', Configuration::API_BASE_URL, \ltrim($uri, '/'));
         }
 
         $parameters['headers'] = $headers;

--- a/src/Apis/FileApi.php
+++ b/src/Apis/FileApi.php
@@ -191,12 +191,12 @@ class FileApi extends AbstractApi implements FileApiInterface
             throw new InvalidArgumentException(\sprintf('Uuid \'%s\' for request not valid', $source));
         }
 
-        $response = $this->request('POST', '/files/local_copy/', [
+        $parameters = [
             'source' => $source,
             'store' => (bool) $store,
-        ]);
+        ];
+        $response = $this->request('POST', '/files/local_copy/', ['body' => \json_encode($parameters)]);
 
-        // Hack
         $data = \json_decode($response->getBody()->getContents(), true);
         if (!isset($data['result']) || !\is_array($data['result'])) {
             throw new \RuntimeException('Unable to deserialize response. Call to support');
@@ -240,7 +240,7 @@ class FileApi extends AbstractApi implements FileApiInterface
             $parameters['pattern'] = $pattern;
         }
 
-        $response = $this->request('POST', '/files/remote_copy/', $parameters);
+        $response = $this->request('POST', '/files/remote_copy/', ['body' => \json_encode($parameters)]);
 
         $result = $this->configuration->getSerializer()
             ->deserialize($response->getBody()->getContents());


### PR DESCRIPTION
Fixed file copy methods between default Uploadcare storage and remote storage (Amazon s3)

Closes: #175

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
