### PR TITLE
Allow transformed URL to sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [3.1.1]
-### Secure URL generation update
+### Secure CDN URLs for transformed images
 - Now you can generate Secure CDN URLs for images with transformations.
 
 ## [3.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based now on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.1]
+### Secure URL generation update
+- Added possibility to generate Security CDN url for image with transformations.
+
 ## [3.1.0]
 ### PHP version update, PDF conversion improvement
 - Dropped support for old PHP versions. You **must** update PHP to 7.1 or a newer version to use this version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 
 ## [3.1.1]
 ### Secure URL generation update
-- Added possibility to generate Security CDN url for image with transformations.
+- Now you can generate Secure CDN URLs for images with transformations.
 
 ## [3.1.0]
 ### PHP version update, PDF conversion improvement

--- a/README.md
+++ b/README.md
@@ -410,7 +410,8 @@ $secureUrlFromApi = $api->file()->generateSecureUrl($file);
 
 ### Secure delivery for transformed images
 
-You can set the custom ACL to Secure URL for images which were transformed with [Image Transformations](https://uploadcare.com/docs/transformations/image/). Set Image UUID and transformation part to `generateSecureUrl` method. Like this:
+You can set a custom ACL on a Secure URL with [Image Transformations](https://uploadcare.com/docs/transformations/image/)
+applied. Just add an Image UUID with transformations to the `generateSecureUrl` method:
 
 ```php
 $api->file()->generateSecureUrl('/*/'); # Access to all files in project

--- a/README.md
+++ b/README.md
@@ -410,8 +410,10 @@ $secureUrlFromApi = $api->file()->generateSecureUrl($file);
 
 ### Secure delivery for transformed images
 
-You can set a custom ACL on a Secure URL with [Image Transformations](https://uploadcare.com/docs/transformations/image/)
-applied. Just add an Image UUID with transformations to the `generateSecureUrl` method:
+You can set a custom ACL on a Secure URL with
+[Image Transformations](https://uploadcare.com/docs/transformations/image/)
+applied. Just add an Image UUID with transformations to the `generateSecureUrl`
+method:
 
 ```php
 $api->file()->generateSecureUrl('/*/'); # Access to all files in project

--- a/README.md
+++ b/README.md
@@ -408,6 +408,15 @@ $secureUrl = $file->generateSecureUrl(); // you can use KeyCdnUrlGenerator or Ak
 $secureUrlFromApi = $api->file()->generateSecureUrl($file);
 ```
 
+### Secure delivery for transformed images
+
+You can set the custom ACL to Secure URL for images which were transformed with [Image Transformations](https://uploadcare.com/docs/transformations/image/). Set Image UUID and transformation part to `generateSecureUrl` method. Like this:
+
+```php
+$api->file()->generateSecureUrl('/*/'); # Access to all files in project
+$api->file()->generateSecureUrl('/{uuid}/-/resize/640x/other/transformations/'); # Access to modified file version
+```
+
 --------------------------------------------------------------------
 
 ## Tests

--- a/php-7.1.Dockerfile
+++ b/php-7.1.Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache git
 
 RUN set -xe \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
-    && pecl install xdebug-2.8.1 \
+    && pecl install xdebug-2.9.8 \
     && docker-php-ext-enable xdebug \
     && apk del --no-network .phpize-deps
 

--- a/php-7.1.Dockerfile
+++ b/php-7.1.Dockerfile
@@ -1,3 +1,4 @@
+FROM composer:latest as composer
 FROM php:7.1-fpm-alpine as php
 
 RUN apk add --no-cache git
@@ -8,7 +9,5 @@ RUN set -xe \
     && docker-php-ext-enable xdebug \
     && apk del --no-network .phpize-deps
 
-RUN curl -sS https://getcomposer.org/installer | php -- \
-        --install-dir=/usr/local/bin \
-        --filename=composer
-
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+WORKDIR /var/www/app

--- a/src/Apis/FileApi.php
+++ b/src/Apis/FileApi.php
@@ -320,7 +320,7 @@ final class FileApi extends AbstractApi implements FileApiInterface
             return $url;
         }
 
-        $regex = \sprintf('/\/%s\/', self::UUID_REGEX);
+        $regex = \sprintf('/\/%s\//', self::UUID_REGEX);
         $result = \preg_match($regex, $url);
         if ($result === false || $result === 0) {
             throw new InvalidArgumentException('URL must contain the file UUID');

--- a/tests/AuthUrl/GenerateSecureUrlTest.php
+++ b/tests/AuthUrl/GenerateSecureUrlTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\AuthUrl;
+
+use PHPUnit\Framework\TestCase;
+use Uploadcare\Api;
+use Uploadcare\Apis\FileApi;
+use Uploadcare\AuthUrl\AuthUrlConfig;
+use Uploadcare\AuthUrl\Token\AkamaiToken;
+use Uploadcare\Configuration;
+use Uploadcare\Exception\InvalidArgumentException;
+
+class GenerateSecureUrlTest extends TestCase
+{
+    /**
+     * @var \Uploadcare\Interfaces\Api\FileApiInterface
+     */
+    private $fileApi;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $key = \bin2hex(\random_bytes(32));
+
+        $authUrlConfig = new AuthUrlConfig('mydomain.com', new AkamaiToken($key, 300));
+        $this->fileApi = new FileApi(Configuration::create('demopublickey', 'demosecretkey')->setAuthUrlConfig($authUrlConfig));
+    }
+
+    public function testWrongObjectInMethod(): void
+    {
+        $object = (object) ['foo' => 'bar'];
+        $this->expectException(InvalidArgumentException::class);
+        $this->fileApi->generateSecureUrl($object);
+    }
+
+    public function testWrongTransformationUrl(): void
+    {
+        $url = '/foo/-bar/baz';
+        $this->expectException(InvalidArgumentException::class);
+        $this->fileApi->generateSecureUrl($url);
+    }
+
+    public function provideValidUrls(): array
+    {
+        return [
+            ['/1a86c6b8-4e77-44c2-9da7-4228ad9a2dd8/-/format/auto/-/quality/smart/-/resize/950x/result.jpg'],
+            ['/*/']
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidUrls
+     */
+    public function testValidUrls(string $url): void
+    {
+        self::assertIsString($this->fileApi->generateSecureUrl($url));
+    }
+}

--- a/tests/AuthUrl/GenerateSecureUrlTest.php
+++ b/tests/AuthUrl/GenerateSecureUrlTest.php
@@ -17,7 +17,7 @@ class GenerateSecureUrlTest extends TestCase
      */
     private $fileApi;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $key = \bin2hex(\random_bytes(32));


### PR DESCRIPTION
## Description

Added possibility to generate Security CDN url for image with transformations.

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
