### PR TITLE
Resolving issue with secure delivery and image transformations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 ### Secure Webhooks
 - Each webhook payload now can be [signed with a secret](https://uploadcare.com/docs/security/secure-webhooks/) to ensure that the request comes from the expected sender.
 - Fix some minor issues.
+- Resolved issue with invalid signed urls being generated for image transformations.
 
 ## [3.1.1]
 ### Secure CDN URLs for transformed images

--- a/src/Apis/FileApi.php
+++ b/src/Apis/FileApi.php
@@ -326,7 +326,9 @@ final class FileApi extends AbstractApi implements FileApiInterface
             throw new InvalidArgumentException('URL must contain the file UUID');
         }
 
-        return $url;
+        // Remove starting and end slash from the uuid with transformation string. The generator url template will
+        // already append these.
+        return trim(rtrim($url, '/'), '/');
     }
 
     /**


### PR DESCRIPTION
## Description

https://github.com/uploadcare/uploadcare-php/issues/186

This fix is intended for the Secure Delivery feature. 

When generating a secure url with transformations, [per the documentation](https://github.com/uploadcare/uploadcare-php#secure-delivery-for-transformed-images), the slash at the beginning and end of the uuid/transformation string must be stripped out **before** passing it off to the AkamaiToken generator. 

When the slashes remain, it yields a valid signed URL with double slashes, which is a invalid path to the Uploadcare asset, presenting a 404 error to the user. The `$generator->getUrlTemplate()` already appends these slashes when constructing and signing the url.


## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
   - Added comment to code to explain change.
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
