### PR TITLE
Hugos changes

### DIFF
--- a/src/Uploader/AbstractUploader.php
+++ b/src/Uploader/AbstractUploader.php
@@ -142,6 +142,24 @@ abstract class AbstractUploader implements UploaderInterface
         return (string) $response['status'];
     }
 
+    public function checkStatusGetFullResponse(string $token)
+    {
+        try {
+            $request = $this->sendRequest('GET', '/from_url/status/', [
+                'query' => ['token' => $token],
+            ])->getBody()->getContents();
+            $response = \json_decode($request, true, 215, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            throw $this->handleException($e);
+        }
+
+        if (!\array_key_exists('status', $response)) {
+            throw new HttpException('Unable to get \'status\' key from response');
+        }
+
+        return $response;
+    }
+
     /**
      * Upload file from content string.
      *

--- a/src/Uploader/AbstractUploader.php
+++ b/src/Uploader/AbstractUploader.php
@@ -101,6 +101,8 @@ abstract class AbstractUploader implements UploaderInterface
             'check_URL_duplicates' => $checkDuplicates ? '1' : '0',
             'save_URL_duplicates' => $storeDuplicates ? '1' : '0',
             'pub_key' => $this->configuration->getPublicKey(),
+			'store' => $store,
+			'filename' => $filename,
         ], $this->makeMetadataParameters($metadata)));
 
         try {

--- a/src/Uploader/AbstractUploader.php
+++ b/src/Uploader/AbstractUploader.php
@@ -88,11 +88,11 @@ abstract class AbstractUploader implements UploaderInterface
         $checkDuplicates = false;
         $storeDuplicates = false;
         if (\array_key_exists('checkDuplicates', $metadata)) {
-            $checkDuplicates = true;
+            $checkDuplicates = $metadata['checkDuplicates'];
             unset($metadata['checkDuplicates']);
         }
         if (\array_key_exists('storeDuplicates', $metadata)) {
-            $storeDuplicates = true;
+            $storeDuplicates = $metadata['storeDuplicates'];
             unset($metadata['storeDuplicates']);
         }
 


### PR DESCRIPTION
## Description

No open issue. Communicated with Dmitry via email.

In Uploadcare\Uploader\AbstractUploader, did the following:

1) In fromUrl function, resolved the issue of $checkDuplicates being set to true if $metadata['checkDuplicates'] value was passed regardless of whether $metadata['checkDuplicates'] was false or true.

2) In fromUrl function, resolved the issue of $storeDuplicatesbeing set to true if $metadata['storeDuplicates'] value was passed regardless of whether $metadata['storeDuplicates'] was false or true.

3) In fromUrl function, resolved the issue of $filename and $store parameters doing nothing.

4) Added new checkStatusGetFullResponse function that returns the entire response rather than just the status. This allows user to get UUID or other info if upload finished.


## Checklist

- [ ] Tests (if applicable)
   Did not perform thorough testing. Just tested for my use case.
- [ ] Documentation (if applicable)
   N/A
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
   Used commit messages.
