### PR TITLE
Remove redundant api call for retreiving metadata

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -120,11 +120,6 @@ final class File implements FileInfoInterface
 
     public function getMetadata(): Metadata
     {
-        return $this->api->getMetadata($this->inner);
-    }
-
-    public function getMetadataInner(): Metadata
-    {
         return $this->inner->getMetadata();
     }
 

--- a/src/File.php
+++ b/src/File.php
@@ -120,7 +120,7 @@ final class File implements FileInfoInterface
 
     public function getMetadata(): Metadata
     {
-        return $this->inner->getMetadata();
+        return $this->api->getMetadata($this->inner);
     }
 
     public function getContentInfo(): ?ContentInfoInterface
@@ -131,5 +131,10 @@ final class File implements FileInfoInterface
     public function getAppdata(): ?AppDataInterface
     {
         return $this->inner->getAppdata();
+    }
+
+    public function getInner(): FileInfoInterface
+    {
+        return $this->inner;
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -123,6 +123,11 @@ final class File implements FileInfoInterface
         return $this->api->getMetadata($this->inner);
     }
 
+    public function getMetadataInner(): Metadata
+    {
+        return $this->inner->getMetadata();
+    }
+
     public function getContentInfo(): ?ContentInfoInterface
     {
         return $this->inner->getContentInfo();
@@ -131,10 +136,5 @@ final class File implements FileInfoInterface
     public function getAppdata(): ?AppDataInterface
     {
         return $this->inner->getAppdata();
-    }
-
-    public function getInner(): FileInfoInterface
-    {
-        return $this->inner;
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -120,7 +120,7 @@ final class File implements FileInfoInterface
 
     public function getMetadata(): Metadata
     {
-        return $this->api->getMetadata($this->inner);
+        return $this->inner->getMetadata();
     }
 
     public function getContentInfo(): ?ContentInfoInterface


### PR DESCRIPTION
Why are we calling here `$this->api->getMetadata()` instead of directly the `$this->inner->getMetadata()`? It makes a unnecessary api call to the API.

## Description

When I use the following code it will make an api request for each file:
```php
$response = $this->api->file()->listFiles(1000);

foreach ($response->getResults() as $file) {
  dump($file->getMetadata()); // Results in an additional api call, while information is already available
}
```


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
