### PR TITLE
Fixing datetime parsing errors

### DIFF
--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -13,7 +13,12 @@ class Serializer implements SerializerInterface
     public const EXCLUDE_PROPERTY_KEY = 'exclude_property';
     public const DATE_FORMAT = 'Y-m-d\TH:i:s.u\Z';
     public const DATE_FORMAT_SHORT = 'Y-m-d\TH:i:s\Z';
-    public const ORIGINAL_DATE_FORMATS = [ 'Y-m-d\TH:i:s', \DateTimeInterface::ATOM, 'Y-m-d\TH:i:s.u' ];
+    public const ORIGINAL_DATE_FORMATS = [
+        \DateTimeInterface::ATOM,
+        'Y-m-d\TH:i:s',
+        'Y-m-d\TH:i:s.u',
+        'Y-m-d\TH:i:s.uP'
+    ];
 
     protected static array $coreTypes = [
         'int' => true,

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -251,6 +251,9 @@ class Serializer implements SerializerInterface
         if ($date === false) {
             $date = \date_create_from_format(self::ORIGINAL_DATE_FORMAT, $dateTime);
         }
+        if ($date === false) {
+            $date = \date_create_from_format(\DateTimeInterface::ATOM, $dateTime);
+        }
 
         if ($date === false) {
             throw new ConversionException(\sprintf('Unable to convert \'%s\' to \'%s\'', $dateTime, \DateTime::class));

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -13,7 +13,7 @@ class Serializer implements SerializerInterface
     public const EXCLUDE_PROPERTY_KEY = 'exclude_property';
     public const DATE_FORMAT = 'Y-m-d\TH:i:s.u\Z';
     public const DATE_FORMAT_SHORT = 'Y-m-d\TH:i:s\Z';
-    public const ORIGINAL_DATE_FORMAT = 'Y-m-d\TH:i:s';
+    public const ORIGINAL_DATE_FORMATS = [ 'Y-m-d\TH:i:s', \DateTimeInterface::ATOM, 'Y-m-d\TH:i:s.u' ];
 
     protected static array $coreTypes = [
         'int' => true,
@@ -248,11 +248,10 @@ class Serializer implements SerializerInterface
         if ($date === false) {
             $date = \date_create_from_format(self::DATE_FORMAT_SHORT, $dateTime);
         }
-        if ($date === false) {
-            $date = \date_create_from_format(self::ORIGINAL_DATE_FORMAT, $dateTime);
-        }
-        if ($date === false) {
-            $date = \date_create_from_format(\DateTimeInterface::ATOM, $dateTime);
+        foreach (self::ORIGINAL_DATE_FORMATS as $dateFormat) {
+            if ($date === false) {
+                $date = \date_create_from_format($dateFormat, $dateTime);
+            }
         }
 
         if ($date === false) {


### PR DESCRIPTION
Denormalizing datetimes would fail in edge cases, I found three.

> Unable to convert '2009-09-15T16:16:06+00:00' to 'DateTime'

> Unable to convert '2016-11-12T07:40:34.650000' to 'DateTime'

> Unable to convert '2010-11-09T19:59:14.060000+01:00' to 'DateTime'

Observed these values in `content_info.image.datetime_original` at these file UUIDs: `ba48689b-63a9-47c2-90bd-33b51fa6c4e2`, `3a2565df-c223-4c6e-b4a8-4f31ea426d2a`.