### PR TITLE
Introduce Rector to fix implicitly nullable parameter warnings

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: [ "7.4", "8.0", "8.1" ]
+        php-versions: [ "7.4", "8.0", "8.4" ]
         phpunit-versions: [ "9" ]
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /psalm.phar
 .phpunit.result.cache
 .php-cs-fixer.cache
+/rector-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based now on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.2.1]
+- Introduce Rector to fix implicitly nullable parameter warnings.
+- Thanks to @kayw-geek for the contribution.
+
 ## [4.2.0]
 - Added [multi-page document conversion](https://uploadcare.com/docs/transformations/document-conversion/#multipage-conversion).
 - Added [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/).
@@ -42,7 +46,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 ### Removed
 - PHP 7.1 support (now minimal version is 7.4, PHP 8.0 is also supported)
 - `FileInfoInterface::getImageInfo()`, `FileInfoInterface::getVideoInfo()`, `FileInfoInterface::getRekognitionInfo()` — see `FileInfoInterface::getContentInfo()`
-### Added 
+### Added
 - Support for [REST API 0.7](https://uploadcare.com/api-refs/rest-api/v0.7.0/)
 - `FileInfoInterface::getContentInfo()`: returns `ContentInfoInterface` with `getMime()` (information about MimeType), `getImage` (`ImageInfoInterface` in case of an image) and `getVideo` (`VideoInfoInterface` in case of a video) methods;
 - `FileInfoInterface::getMetadata()` method returns file associated metadata array-accessible object;
@@ -105,7 +109,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 ### Fix
 - Added support for guzzlehttp/guzzle:^7.
 
-## [3.0.0] 
+## [3.0.0]
 ### BREAKING CHANGES
 - You must update PHP to 5.6 or a newer version.
 - This **completely new** version **is not** backward compatibile with the

--- a/api-samples/rest-api/delete-files-storage.php
+++ b/api-samples/rest-api/delete-files-storage.php
@@ -5,4 +5,4 @@ $api = (new Uploadcare\Api($configuration))->file();
 $fileInfo = $api->fileInfo('1bac376c-aa7e-4356-861b-dd2657b5bfd2');
 $api->deleteFile($fileInfo);
 
-echo \sprintf('File \'%s\' deleted at \'%s\'', $fileInfo->getUuid(), $fileInfo->getDatetimeRemoved()->format(\DateTimeInterface::ATOM));
+echo \sprintf('File \'%s\' deleted at \'%s\'', $fileInfo->getUuid(), $fileInfo->getDatetimeRemoved()->format(DateTimeInterface::ATOM));

--- a/api-samples/rest-api/delete-files-uuid-metadata-key.php
+++ b/api-samples/rest-api/delete-files-uuid-metadata-key.php
@@ -4,7 +4,7 @@ $configuration = Uploadcare\Configuration::create((string) $_ENV['UPLOADCARE_PUB
 $metadataApi = (new Uploadcare\Api($configuration))->metadata();
 try {
     $metadataApi->removeKey('1bac376c-aa7e-4356-861b-dd2657b5bfd2', 'pet');
-} catch (\Throwable $e) {
+} catch (Throwable $e) {
     echo \sprintf('Error while key removing: %s', $e->getMessage());
 }
 echo 'Key was successfully removed';

--- a/api-samples/rest-api/delete-files-uuid-storage.php
+++ b/api-samples/rest-api/delete-files-uuid-storage.php
@@ -2,4 +2,4 @@
 
 $configuration = Uploadcare\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);
 $fileInfo = (new Uploadcare\Api($configuration))->file()->deleteFile('1bac376c-aa7e-4356-861b-dd2657b5bfd2');
-echo \sprintf('File \'%s\' deleted at \'%s\'', $fileInfo->getUuid(), $fileInfo->getDatetimeRemoved()->format(\DateTimeInterface::ATOM));
+echo \sprintf('File \'%s\' deleted at \'%s\'', $fileInfo->getUuid(), $fileInfo->getDatetimeRemoved()->format(DateTimeInterface::ATOM));

--- a/api-samples/rest-api/delete-groups-uuid.php
+++ b/api-samples/rest-api/delete-groups-uuid.php
@@ -4,7 +4,7 @@ $configuration = Uploadcare\Configuration::create((string) $_ENV['UPLOADCARE_PUB
 $api = (new Uploadcare\Api($configuration))->group();
 try {
     $api->removeGroup('c5bec8c7-d4b6-4921-9e55-6edb027546bc~1');
-} catch (\Throwable $e) {
+} catch (Throwable $e) {
     echo \sprintf('Error while group deletion: %s', $e->getMessage());
 }
 echo 'Group successfully deleted';

--- a/api-samples/rest-api/put-files-storage.php
+++ b/api-samples/rest-api/put-files-storage.php
@@ -12,5 +12,5 @@ foreach ($result->getResult() as $result) {
         continue;
     }
 
-    \sprintf('Result %s is stored at %s', $result->getUuid(), $result->getDatetimeStored()->format(\DateTimeInterface::ATOM));
+    \printf('Result %s is stored at %s', $result->getUuid(), $result->getDatetimeStored()->format(DateTimeInterface::ATOM));
 }

--- a/api-samples/rest-api/put-files-uuid-storage.php
+++ b/api-samples/rest-api/put-files-uuid-storage.php
@@ -4,4 +4,4 @@ $configuration = Uploadcare\Configuration::create((string) $_ENV['UPLOADCARE_PUB
 $api = (new Uploadcare\Api($configuration))->file();
 $result = $api->storeFile('1bac376c-aa7e-4356-861b-dd2657b5bfd2');
 
-echo \sprintf('File %s is stored at %s', $result->getUuid(), $result->getDatetimeStored()->format(\DateTimeInterface::ATOM));
+echo \sprintf('File %s is stored at %s', $result->getUuid(), $result->getDatetimeStored()->format(DateTimeInterface::ATOM));

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "friendsofphp/php-cs-fixer": "^3.11",
     "phpunit/phpunit": "^9.5",
     "rector/rector": "^2.1",
+    "symfony/string": "^6.4",
     "symfony/dotenv": "^5.4",
     "symfony/var-dumper": "^5.4",
     "vimeo/psalm": "^4.27"

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "fakerphp/faker": "^1.20",
     "friendsofphp/php-cs-fixer": "^3.11",
     "phpunit/phpunit": "^9.5",
+    "rector/rector": "^2.1",
     "symfony/dotenv": "^5.4",
     "symfony/var-dumper": "^5.4",
     "vimeo/psalm": "^4.27"

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,19 @@
+<?php
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules(
+        [Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector::class],
+    )
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/tools',
+        __DIR__ . '/api-samples',
+    ])
+    ->withCache(
+        'rector-cache',
+        Rector\Caching\ValueObject\Storage\FileCacheStorage::class,
+    )
+    ->withParallel();

--- a/src/Apis/AddonsApi.php
+++ b/src/Apis/AddonsApi.php
@@ -41,7 +41,7 @@ class AddonsApi extends AbstractApi implements AddonsApiInterface
         return $this->getResponseParameter($response, 'status');
     }
 
-    public function requestAntivirusScan($id, bool $purge = null): string
+    public function requestAntivirusScan($id, ?bool $purge = null): string
     {
         $parameters = ['target' => (string) $id];
         if (\is_bool($purge)) {

--- a/src/Apis/FileApi.php
+++ b/src/Apis/FileApi.php
@@ -5,13 +5,13 @@ namespace Uploadcare\Apis;
 use Psr\Http\Message\ResponseInterface;
 use Uploadcare\AuthUrl\Token\AkamaiToken;
 use Uploadcare\Exception\InvalidArgumentException;
+use Uploadcare\{File as FileDecorator, File\File, File\FileCollection, File\Metadata};
 use Uploadcare\FileCollection as FileCollectionDecorator;
 use Uploadcare\Interfaces\Api\FileApiInterface;
 use Uploadcare\Interfaces\AuthUrl\AuthUrlConfigInterface;
 use Uploadcare\Interfaces\File\{CollectionInterface, FileInfoInterface};
 use Uploadcare\Interfaces\Response\{BatchResponseInterface, ListResponseInterface};
 use Uploadcare\Response\{BatchFileResponse, FileListResponse};
-use Uploadcare\{File as FileDecorator, File\File, File\FileCollection, File\Metadata};
 
 /**
  * File Api.
@@ -202,7 +202,7 @@ final class FileApi extends AbstractApi implements FileApiInterface
     public function copyToLocalStorage($source, bool $store): FileInfoInterface
     {
         $source = (string) $source;
-        [$uuid, ] = \explode('/', $source);
+        [$uuid] = \explode('/', $source);
         if (!\uuid_is_valid($uuid)) {
             throw new InvalidArgumentException(\sprintf('Uuid \'%s\' for request not valid', $source));
         }
@@ -244,12 +244,12 @@ final class FileApi extends AbstractApi implements FileApiInterface
      * @param bool                     $makePublic true to make copied files available via public links, false to reverse the behavior
      * @param string|null              $pattern    Enum: "${default}" "${auto_filename}" "${effects}" "${filename}" "${uuid}" "${ext}" The parameter is used to specify file names Uploadcare passes to a custom storage. In case the parameter is omitted, we use pattern of your custom storage. Use any combination of allowed values.
      */
-    public function copyToRemoteStorage($source, string $target, bool $makePublic = true, string $pattern = null): string
+    public function copyToRemoteStorage($source, string $target, bool $makePublic = true, ?string $pattern = null): string
     {
         if ($source instanceof FileInfoInterface) {
             $source = $source->getUuid();
         }
-        [$uuid, ] = \explode('/', $source);
+        [$uuid] = \explode('/', $source);
         if (!\uuid_is_valid($uuid)) {
             throw new InvalidArgumentException(\sprintf('Uuid \'%s\' for request not valid', $source));
         }

--- a/src/Apis/WebhookApi.php
+++ b/src/Apis/WebhookApi.php
@@ -41,7 +41,7 @@ final class WebhookApi extends AbstractApi implements WebhookApiInterface
     /**
      * {@inheritDoc}
      */
-    public function createWebhook(string $targetUrl, bool $isActive = true, string $signingSecret = null, string $event = 'file.uploaded'): WebhookInterface
+    public function createWebhook(string $targetUrl, bool $isActive = true, ?string $signingSecret = null, string $event = 'file.uploaded'): WebhookInterface
     {
         if ($signingSecret !== null) {
             $signingSecret = \substr($signingSecret, 0, 32);

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -5,9 +5,9 @@ namespace Uploadcare;
 use GuzzleHttp\ClientInterface;
 use Uploadcare\Client\ClientFactory;
 use Uploadcare\Interfaces\AuthUrl\AuthUrlConfigInterface;
+use Uploadcare\Interfaces\{ClientFactoryInterface, ConfigurationInterface};
 use Uploadcare\Interfaces\Serializer\{SerializerFactoryInterface, SerializerInterface};
 use Uploadcare\Interfaces\SignatureInterface;
-use Uploadcare\Interfaces\{ClientFactoryInterface, ConfigurationInterface};
 use Uploadcare\Security\Signature;
 use Uploadcare\Serializer\SerializerFactory;
 
@@ -34,7 +34,7 @@ final class Configuration implements ConfigurationInterface
      * @param string $secretKey     Uploadcare API private key
      * @param array  $clientOptions Parameters for Http client (proxy, special headers, etc.)
      */
-    public static function create(string $publicKey, string $secretKey, array $clientOptions = [], ClientFactoryInterface $clientFactory = null, SerializerFactoryInterface $serializerFactory = null): Configuration
+    public static function create(string $publicKey, string $secretKey, array $clientOptions = [], ?ClientFactoryInterface $clientFactory = null, ?SerializerFactoryInterface $serializerFactory = null): Configuration
     {
         $signature = new Signature($secretKey);
         $framework = $clientOptions['framework'] ?? null;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -16,7 +16,7 @@ use Uploadcare\Serializer\SerializerFactory;
  */
 final class Configuration implements ConfigurationInterface
 {
-    public const LIBRARY_VERSION = 'v4.2.0';
+    public const LIBRARY_VERSION = 'v4.2.1';
     public const API_VERSION = '0.7';
     public const API_BASE_URL = 'api.uploadcare.com';
     public const USER_AGENT_TEMPLATE = 'PHPUploadcare/{lib-version}/{publicKey} (PHP/{lang-version})';

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\RequestInterface;
 
 class HttpException extends \RuntimeException
 {
-    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         if ($previous !== null) {
             $message = $this->makeMessage($previous, $message);

--- a/src/Exception/Upload/AbstractClientException.php
+++ b/src/Exception/Upload/AbstractClientException.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Psr7\Message;
 
 abstract class AbstractClientException extends \RuntimeException
 {
-    public function __construct(string $message = '', int $code = 0, \Exception $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?\Exception $previous = null)
     {
         if ($previous instanceof ClientException) {
             $code = $previous->getCode();

--- a/src/Exception/Upload/ThrottledException.php
+++ b/src/Exception/Upload/ThrottledException.php
@@ -8,7 +8,7 @@ class ThrottledException extends AbstractClientException
 {
     private int $retryAfter = 10;
 
-    public function __construct(string $message = '', int $code = 0, \Exception $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/File/AppData/AwsModerationLabel.php
+++ b/src/File/AppData/AwsModerationLabel.php
@@ -9,7 +9,7 @@ class AwsModerationLabel implements AwsModerationLabelInterface, SerializableInt
 {
     private ?float $confidence = null;
     private ?string $name = null;
-    private ?string  $parentName = null;
+    private ?string $parentName = null;
 
     public static function rules(): array
     {

--- a/src/File/ContentInfo/Video.php
+++ b/src/File/ContentInfo/Video.php
@@ -78,9 +78,6 @@ final class Video implements VideoInterface, SerializableInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getCodec(): ?string
     {
         return $this->codec;

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -194,7 +194,7 @@ final class File implements FileInfoInterface, SerializableInterface
         return $this->variations;
     }
 
-    public function setVariations(array $variations = null): self
+    public function setVariations(?array $variations = null): self
     {
         $this->variations = $variations;
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -2,9 +2,9 @@
 
 namespace Uploadcare;
 
-use Uploadcare\Apis\{FileApi, GroupApi};
-use Uploadcare\Interfaces\File\CollectionInterface;
+use Uploadcare\Apis\{FileApi};
 use Uploadcare\Interfaces\{ConfigurationInterface, GroupInterface};
+use Uploadcare\Interfaces\File\CollectionInterface;
 
 /**
  * Decorated Group.

--- a/src/Interfaces/Api/WebhookApiInterface.php
+++ b/src/Interfaces/Api/WebhookApiInterface.php
@@ -28,7 +28,7 @@ interface WebhookApiInterface
      * @see https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Webhook
      * @see https://uploadcare.com/docs/webhooks/
      */
-    public function createWebhook(string $targetUrl, bool $isActive = true, string $signingSecret = null, string $event = 'file.uploaded'): WebhookInterface;
+    public function createWebhook(string $targetUrl, bool $isActive = true, ?string $signingSecret = null, string $event = 'file.uploaded'): WebhookInterface;
 
     /**
      * @param array $parameters Parameters for update: string `target_url`, bool `is_active`

--- a/src/Interfaces/File/CollectionInterface.php
+++ b/src/Interfaces/File/CollectionInterface.php
@@ -19,9 +19,9 @@ interface CollectionInterface extends \Countable, \IteratorAggregate, \ArrayAcce
     public static function elementClass(): string;
 
     /**
-     * @return true
-     *
      * @psalm-param T $element
+     *
+     * @return true
      */
     public function add($element): bool;
 
@@ -37,9 +37,9 @@ interface CollectionInterface extends \Countable, \IteratorAggregate, \ArrayAcce
     /**
      * @param string|int $key
      *
-     * @return mixed Removed element
-     *
      * @psalm-param TKey $key
+     *
+     * @return mixed Removed element
      *
      * @psalm-return T|null
      */
@@ -119,9 +119,9 @@ interface CollectionInterface extends \Countable, \IteratorAggregate, \ArrayAcce
     public function map(\Closure $func): self;
 
     /**
-     * @return int|string|bool
-     *
      * @psalm-param T $element
+     *
+     * @return int|string|bool
      *
      * @psalm-return TKey|false
      */

--- a/src/Interfaces/GroupInterface.php
+++ b/src/Interfaces/GroupInterface.php
@@ -21,6 +21,7 @@ interface GroupInterface
 
     /**
      * Date and time when files in a group were stored.
+     *
      * @deprecated
      */
     public function getDatetimeStored(): ?\DateTimeInterface;

--- a/src/Interfaces/UploaderInterface.php
+++ b/src/Interfaces/UploaderInterface.php
@@ -25,21 +25,21 @@ interface UploaderInterface
      *
      * @throws InvalidArgumentException
      */
-    public function fromPath(string $path, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
+    public function fromPath(string $path, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
 
     /**
      * Upload file from remote URL. Returns token to check status.
      *
      * @throws InvalidArgumentException
      */
-    public function fromUrl(string $url, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): string;
+    public function fromUrl(string $url, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): string;
 
     /**
      * Synchronically upload a file from a remote URL. Returns FileInfoInterface.
      *
      * @throws InvalidArgumentException|HttpException
      */
-    public function syncUploadFromUrl(string $url, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
+    public function syncUploadFromUrl(string $url, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
 
     /**
      * Upload file from resource opened by `\fopen()`.
@@ -48,21 +48,21 @@ interface UploaderInterface
      *
      * @throws InvalidArgumentException
      */
-    public function fromResource($handle, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
+    public function fromResource($handle, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
 
     /**
      * Upload file from content string.
      *
      * @throws InvalidArgumentException
      */
-    public function fromContent(string $content, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
+    public function fromContent(string $content, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
 
     /**
      * Check the status of a task to fetch/upload a file from a URL.
      *
      * @param string $token token received from `fromUrl` method
      *
-     * @see \Uploadcare\Interfaces\UploaderInterface::fromUrl
+     * @see UploaderInterface::fromUrl
      *
      * @throws HttpException
      */

--- a/src/Response/GroupListResponse.php
+++ b/src/Response/GroupListResponse.php
@@ -95,7 +95,7 @@ final class GroupListResponse implements ListResponseInterface, SerializableInte
         return $this->results;
     }
 
-    public function addResult(GroupInterface $result = null): self
+    public function addResult(?GroupInterface $result = null): self
     {
         if ($result !== null && !$this->results->contains($result)) {
             $this->results->add($result);

--- a/src/Response/WebhookResponse.php
+++ b/src/Response/WebhookResponse.php
@@ -78,9 +78,6 @@ class WebhookResponse implements WebhookInterface, SerializableInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getTargetUrl(): ?string
     {
         return $this->targetUrl;

--- a/src/Security/Signature.php
+++ b/src/Security/Signature.php
@@ -14,7 +14,7 @@ class Signature implements SignatureInterface
      * @param string   $secretKey Uploadcare private key
      * @param int|null $ttl       Signature time-to-life
      */
-    public function __construct(string $secretKey, int $ttl = null)
+    public function __construct(string $secretKey, ?int $ttl = null)
     {
         $this->secretKey = $secretKey;
         if ($ttl === null || $ttl > self::MAX_TTL) {
@@ -54,7 +54,7 @@ class Signature implements SignatureInterface
     /**
      * {@inheritDoc}
      */
-    public function getAuthHeaderString(string $method, string $uri, string $data, string $contentType = 'application/json', \DateTimeInterface $date = null): string
+    public function getAuthHeaderString(string $method, string $uri, string $data, string $contentType = 'application/json', ?\DateTimeInterface $date = null): string
     {
         $uri = \sprintf('/%s', \ltrim($uri, '/'));
         $data = \md5($data);

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -17,7 +17,7 @@ class Serializer implements SerializerInterface
         \DateTimeInterface::ATOM,
         'Y-m-d\TH:i:s',
         'Y-m-d\TH:i:s.u',
-        'Y-m-d\TH:i:s.uP'
+        'Y-m-d\TH:i:s.uP',
     ];
 
     protected static array $coreTypes = [
@@ -135,7 +135,7 @@ class Serializer implements SerializerInterface
             throw new SerializerException(\sprintf('Class \'%s\' must implements the \'%s\' interface', $className, SerializableInterface::class));
         }
 
-        $class = new $className;
+        $class = new $className();
         $excluded = $context[self::EXCLUDE_PROPERTY_KEY] ?? [];
 
         $rules = $class::rules();

--- a/src/Uploader/AbstractUploader.php
+++ b/src/Uploader/AbstractUploader.php
@@ -5,8 +5,8 @@ namespace Uploadcare\Uploader;
 use GuzzleHttp\Exception\{ClientException, GuzzleException};
 use Psr\Http\Message\ResponseInterface;
 use Uploadcare\Apis\FileApi;
-use Uploadcare\Exception\Upload\{AccountException, FileTooLargeException, RequestParametersException, ThrottledException};
 use Uploadcare\Exception\{HttpException, InvalidArgumentException};
+use Uploadcare\Exception\Upload\{AccountException, FileTooLargeException, RequestParametersException, ThrottledException};
 use Uploadcare\File\File;
 use Uploadcare\File\Metadata;
 use Uploadcare\Interfaces\{ConfigurationInterface, File\FileInfoInterface, SignatureInterface, UploaderInterface};
@@ -68,14 +68,14 @@ abstract class AbstractUploader implements UploaderInterface
      *
      * @throws InvalidArgumentException
      */
-    abstract public function fromResource($handle, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
+    abstract public function fromResource($handle, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface;
 
     /**
      * Upload file from local path.
      *
      * @throws InvalidArgumentException
      */
-    public function fromPath(string $path, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
+    public function fromPath(string $path, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
     {
         if (!\file_exists($path) || !\is_readable($path)) {
             throw new InvalidArgumentException(\sprintf('Unable to read \'%s\': file not found or not readable', $path));
@@ -84,7 +84,7 @@ abstract class AbstractUploader implements UploaderInterface
         return $this->fromResource(\fopen($path, 'rb'), $mimeType, $filename, $store, $metadata);
     }
 
-    public function syncUploadFromUrl(string $url, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
+    public function syncUploadFromUrl(string $url, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
     {
         $token = $this->fromUrl($url, $mimeType, $filename, $store, $metadata);
         do {
@@ -99,7 +99,7 @@ abstract class AbstractUploader implements UploaderInterface
      *
      * @throws InvalidArgumentException
      */
-    public function fromUrl(string $url, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): string
+    public function fromUrl(string $url, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): string
     {
         $checkDuplicates = false;
         $storeDuplicates = false;
@@ -181,7 +181,7 @@ abstract class AbstractUploader implements UploaderInterface
      *
      * @throws InvalidArgumentException
      */
-    public function fromContent(string $content, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
+    public function fromContent(string $content, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
     {
         $res = \fopen('php://temp', 'rb+');
         \fwrite($res, $content);

--- a/src/Uploader/Uploader.php
+++ b/src/Uploader/Uploader.php
@@ -26,7 +26,7 @@ class Uploader extends AbstractUploader
     /**
      * @param resource $handle
      */
-    public function fromResource($handle, string $mimeType = null, string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
+    public function fromResource($handle, ?string $mimeType = null, ?string $filename = null, string $store = 'auto', array $metadata = []): FileInfoInterface
     {
         try {
             $this->checkResource($handle);
@@ -81,7 +81,7 @@ class Uploader extends AbstractUploader
     /**
      * @param resource $handle
      */
-    private function uploadByParts($handle, int $fileSize, string $mimeType = null, string $filename = null, string $store = null, array $metadata = []): ResponseInterface
+    private function uploadByParts($handle, int $fileSize, ?string $mimeType = null, ?string $filename = null, ?string $store = null, array $metadata = []): ResponseInterface
     {
         if ($filename === null) {
             $filename = \uuid_create();

--- a/tests/Api/FileApiAnswersTest.php
+++ b/tests/Api/FileApiAnswersTest.php
@@ -50,7 +50,7 @@ class FileApiAnswersTest extends TestCase
         return new Client(['handler' => $stack]);
     }
 
-    public function getConfig(ClientInterface $client = null): ConfigurationInterface
+    public function getConfig(?ClientInterface $client = null): ConfigurationInterface
     {
         $configuration = Configuration::create('demo-public-key', 'demo-private-key');
         if ($client === null) {

--- a/tests/Api/FileApiConvertCollectionTest.php
+++ b/tests/Api/FileApiConvertCollectionTest.php
@@ -65,8 +65,6 @@ class FileApiConvertCollectionTest extends TestCase
     /**
      * @dataProvider provideWrongData
      *
-     * @param $item
-     *
      * @throws \ReflectionException
      */
     public function testExceptionWithWrongObject($item): void

--- a/tests/Conversion/VideoUrlBuilderTest.php
+++ b/tests/Conversion/VideoUrlBuilderTest.php
@@ -74,8 +74,6 @@ class VideoUrlBuilderTest extends TestCase
 
     /**
      * @dataProvider generateRequests
-     *
-     * @param $url
      */
     public function testVideoUrlGeneration(string $url, VideoEncodingRequest $request): void
     {

--- a/tests/Decorated/DecoratedWebhookTest.php
+++ b/tests/Decorated/DecoratedWebhookTest.php
@@ -46,8 +46,6 @@ class DecoratedWebhookTest extends TestCase
     /**
      * @dataProvider commonMethods
      *
-     * @param $method
-     *
      * @throws \ReflectionException
      */
     public function testCommonMethods(string $method): void

--- a/tests/Serializer/DeserializerTest.php
+++ b/tests/Serializer/DeserializerTest.php
@@ -99,7 +99,7 @@ class DeserializerTest extends TestCase
     /**
      * @dataProvider provideDateInDifferentFormats
      */
-    public function testVariousDateFormats(string $date, string $exception = null): void
+    public function testVariousDateFormats(string $date, ?string $exception = null): void
     {
         $serializer = $this->getSerializer();
         $denormalizeDate = (new \ReflectionObject($serializer))->getMethod('denormalizeDate');

--- a/tests/Uploader/UploaderServiceTest.php
+++ b/tests/Uploader/UploaderServiceTest.php
@@ -23,7 +23,7 @@ use Uploadcare\Uploader\Uploader;
  */
 class UploaderServiceTest extends TestCase
 {
-    private function getMockUploader(Configuration $configuration = null): UploaderInterface
+    private function getMockUploader(?Configuration $configuration = null): UploaderInterface
     {
         $uploader = $this->getMockBuilder(Uploader::class)
             ->setConstructorArgs([$configuration ?: $this->getConf()])
@@ -36,7 +36,7 @@ class UploaderServiceTest extends TestCase
         return $uploader;
     }
 
-    private function getConf(ClientInterface $client = null): ConfigurationInterface
+    private function getConf(?ClientInterface $client = null): ConfigurationInterface
     {
         return new Configuration('demo-public-key', new Signature('demo-private-key'), $client ?: $this->mockClient(), $this->getSerializer());
     }


### PR DESCRIPTION
## Description

Introduce Rector to fix implicitly nullable parameter warnings for PHP 8.4 compatibility.

PHP 8.4 no longer supports implicitly nullable parameters. This PR uses Rector to automatically convert implicit nullable parameters to explicit nullable types, preventing deprecation warnings.

```php
// Before
function example(string $name = null) { }

// After  
function example(?string $name = null) { }
```
## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development tool for automated code upgrades and included its configuration.

* **Refactor**
  * Clarified nullable parameter types across the library for better PHP 8.4 compatibility.
  * Cleaned up imports and minor code formatting.

* **Chores**
  * Updated CI test matrix to include PHP 8.4.
  * Ignored rector cache directory in repository.

* **Style**
  * Small docblock and changelog formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->